### PR TITLE
make view methods that loadAssetCacheRO check the re-entrancy guard i…

### DIFF
--- a/contracts/BaseLogic.sol
+++ b/contracts/BaseLogic.sol
@@ -257,6 +257,11 @@ abstract contract BaseLogic is BaseModule {
     }
 
     function loadAssetCacheRO(address underlying, AssetStorage storage assetStorage) internal view returns (AssetCache memory assetCache) {
+        require(reentrancyLock == REENTRANCYLOCK__UNLOCKED, "e/ro-reentrancy");
+        initAssetCache(underlying, assetStorage, assetCache);
+    }
+
+    function internalLoadAssetCacheRO(address underlying, AssetStorage storage assetStorage) internal view returns (AssetCache memory assetCache) {
         initAssetCache(underlying, assetStorage, assetCache);
     }
 

--- a/contracts/modules/RiskManager.sol
+++ b/contracts/modules/RiskManager.sol
@@ -250,7 +250,7 @@ contract RiskManager is IRiskManager, BaseLogic {
     function getPrice(address underlying) external view override returns (uint twap, uint twapPeriod) {
         AssetConfig memory config = resolveAssetConfig(underlying);
         AssetStorage storage assetStorage = eTokenLookup[config.eTokenAddress];
-        AssetCache memory assetCache = loadAssetCacheRO(underlying, assetStorage);
+        AssetCache memory assetCache = internalLoadAssetCacheRO(underlying, assetStorage);
 
         (twap, twapPeriod) = getPriceInternal(assetCache, config);
     }
@@ -261,7 +261,7 @@ contract RiskManager is IRiskManager, BaseLogic {
     function getPriceFull(address underlying) external view override returns (uint twap, uint twapPeriod, uint currPrice) {
         AssetConfig memory config = resolveAssetConfig(underlying);
         AssetStorage storage assetStorage = eTokenLookup[config.eTokenAddress];
-        AssetCache memory assetCache = loadAssetCacheRO(underlying, assetStorage);
+        AssetCache memory assetCache = internalLoadAssetCacheRO(underlying, assetStorage);
 
         (twap, twapPeriod) = getPriceInternal(assetCache, config);
 

--- a/test/maliciousToken.js
+++ b/test/maliciousToken.js
@@ -152,6 +152,21 @@ et.testSet({
 
 
 .test({
+    desc: "deposit - transfer from reenters view method",
+    actions: ctx => [
+        { send: 'tokens.TST.configure', args: ['transfer-from/call', et.abiEncode(
+            ['address', 'bytes'],
+            [
+                ctx.contracts.eTokens.eTST.address,
+                ctx.contracts.eTokens.eTST.interface.encodeFunctionData('balanceOfUnderlying', [ctx.wallet.address]),
+            ]
+        )]},
+        { send: 'eTokens.eTST.deposit', args: [0, et.eth(1)], expectError: 'e/ro-reentrancy', },
+    ],
+})
+
+
+.test({
     desc: "withdraw - underflow",
     actions: ctx => [
         { send: 'tokens.TST.configure', args: ['transfer/underflow', []] }, 


### PR DESCRIPTION
…s unlocked

- This is in case external code is executed during (for example) a swap, this external
  code cannot see temporarily inconsistent states