### PR TITLE
fix natspec documentation of liquidate() to indicate that amounts mus…

### DIFF
--- a/contracts/modules/Liquidation.sol
+++ b/contracts/modules/Liquidation.sol
@@ -193,8 +193,8 @@ contract Liquidation is BaseLogic {
     /// @param violator Address that may be in collateral violation
     /// @param underlying Token that is to be repayed
     /// @param collateral Token that is to be seized
-    /// @param repay The amount of underlying DTokens to be transferred from violator to sender, in units of underlying
-    /// @param minYield The minimum acceptable amount of collateral ETokens to be transferred from violator to sender, in units of collateral
+    /// @param repay The amount of underlying DTokens to be transferred from violator to sender, in units of underlying normalised to 18 decimals
+    /// @param minYield The minimum acceptable amount of collateral ETokens to be transferred from violator to sender, in units of collateral normalised to 18 decimals
     function liquidate(address violator, address underlying, address collateral, uint repay, uint minYield) external nonReentrant {
         require(accountLookup[violator].deferLiquidityStatus == DEFERLIQUIDITY__NONE, "e/liq/violator-liquidity-deferred");
 

--- a/test/liquidation.js
+++ b/test/liquidation.js
@@ -828,12 +828,16 @@ et.testSet({
           },
         },
 
+        // minYield failure
+
+        { send: 'liquidation.liquidate', args: [ctx.wallet4.address, ctx.contracts.tokens.TST.address, ctx.contracts.tokens.TST9.address, () => ctx.stash.repay, et.eth('0.81')], expectError: 'e/liq/min-yield', },
+
         // Successful liquidation
 
         { call: 'eTokens.eTST.reserveBalanceUnderlying', args: [], equals: [0, '0.000000000001'], },
         { call: 'dTokens.dTST.balanceOf', args: [ctx.wallet4.address], equals: et.eth('20'), },
 
-        { send: 'liquidation.liquidate', args: [ctx.wallet4.address, ctx.contracts.tokens.TST.address, ctx.contracts.tokens.TST9.address, () => ctx.stash.repay, 0], },
+        { send: 'liquidation.liquidate', args: [ctx.wallet4.address, ctx.contracts.tokens.TST.address, ctx.contracts.tokens.TST9.address, () => ctx.stash.repay, et.eth('0.8')], },
 
         // liquidator:
         { call: 'dTokens.dTST.balanceOf', args: [ctx.wallet.address], equals: () => ctx.stash.repay, },


### PR DESCRIPTION
…t be normalised to 18 decimals

- Updates test to confirm this is the case for minYield