### PR TITLE
Fix: getPriceFull forwarded pricing type

### DIFF
--- a/contracts/modules/RiskManager.sol
+++ b/contracts/modules/RiskManager.sol
@@ -273,7 +273,7 @@ contract RiskManager is IRiskManager, BaseLogic {
 
         if (pricingType == PRICINGTYPE__PEGGED) {
             currPrice = 1e18;
-        } else if (pricingType == PRICINGTYPE__UNISWAP3_TWAP || pricingType == PRICINGTYPE__FORWARDED) {
+        } else if (pricingType == PRICINGTYPE__UNISWAP3_TWAP) {
             address pool = computeUniswapPoolAddress(newUnderlying, uint24(pricingParameters));
             (uint160 sqrtPriceX96,,,,,,) = IUniswapV3Pool(pool).slot0();
             currPrice = decodeSqrtPriceX96(newUnderlying, underlyingDecimalsScaler, sqrtPriceX96);


### PR DESCRIPTION
if given asset has `PRICINGTYPE__FORWARDED`, the `resolvePricingConfig` function returns the `pricingType` of the asset the pricing is forwarded to. hence, the `pricingType` must never be equal to `PRICINGTYPE__FORWARDED` after the pricing config is resolved.